### PR TITLE
Fixes compiler errors/warnings for our pellucid fork of mithril-hx 0.21.3

### DIFF
--- a/example/DashboardModule.hx
+++ b/example/DashboardModule.hx
@@ -47,7 +47,7 @@ class DashboardModule implements Module<Dynamic>
 		);
 	}
 
-	public function view() {
+	public function view(?ctrl : Null<Dynamic>) : ViewOutput {
 		[
 			m("h1", "Welcome!"),
 			m("p", "Choose your app:"),

--- a/src/mithril/M.hx
+++ b/src/mithril/M.hx
@@ -2,7 +2,7 @@ package mithril;
 
 import js.Browser;
 import js.html.Document;
-import js.html.DOMWindow;
+import js.html.Window;
 import js.html.Element;
 import js.Error;
 import js.html.Event;
@@ -79,9 +79,15 @@ typedef Deferred<T, T2> = {
 	function reject(value : T2) : Void;
 }
 
+// Addresses this compiler error:
+// Structures with new are deprecated, use haxe.Constraints.Constructible instead
+#if (haxe_ver >= "3.3")
+typedef DataConstructible<T> = haxe.Constraints.Constructible<T -> Void>;
+#else
 typedef DataConstructible<T> = {
 	public function new(data : T) : Void;
 }
+#end
 
 /**
  * Plenty of optional fields for this one:

--- a/webshop.hxml
+++ b/webshop.hxml
@@ -1,5 +1,6 @@
 -cp example
--lib mithril
+#-lib mithril
+-cp src
 -lib jQueryExtern
 -js bin/webshop/webshop.js
 -main webshop.Webshop


### PR DESCRIPTION
- Fix compiler error in DashboardModule about parameter type mismatch
- change js.html.DOMWindow to js.html.Window
- use haxe.Constraints.Constructible if available
- compile this lib with its own src, rather than a mystery global mithril library
